### PR TITLE
Fix parseTime not working for MySQL

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -86,7 +86,11 @@ func (c *SQLConnection) GetDatabase() *sqlx.DB {
 	if err = retry(c.L, time.Second*15, time.Minute*2, func() error {
 		c.L.Infof("Connecting with %s", c.URL.Scheme+"://*:*@"+c.URL.Host+c.URL.Path+"?"+clean.RawQuery)
 
-		clean.Query().Set("parseTime", "true")
+		if clean.Scheme == "mysql" {
+			q := clean.Query()
+			q.Set("parseTime", "true")
+			clean.RawQuery = q.Encode()
+		}
 
 		u := clean.String()
 		if clean.Scheme == "mysql" {

--- a/connector_test.go
+++ b/connector_test.go
@@ -123,6 +123,10 @@ func TestSQLConnection(t *testing.T) {
 			tc.s.L = logrus.New()
 			db := tc.s.GetDatabase()
 			require.Nil(t, db.Ping())
+
+			// Test for parseTime support in MySQL
+			tim := &time.Time{}
+			require.Nil(t, db.QueryRow("SELECT NOW()").Scan(&tim))
 		})
 	}
 }


### PR DESCRIPTION
The current way did not work for settings `parseTime` to true for MySQL, because `Query().Set()` does not update the `RawQuery`. I discovered this issue by using Hydra (master branch) in combination with MySQL:

Request:
```
GET /oauth2/auth/requests/login/319fbd2e7e234bf09bf5e40abde0a0a4 HTTP/1.1
Host: localhost:4444
Accept: application/json
Content-Type: application/json
```

Response:
```
{
    "error": {
        "code": 500,
        "message": "sql: Scan error on column index 8: unsupported Scan, storing driver.Value type []uint8 into type *time.Time"
    }
}
```